### PR TITLE
chore: update upload-artifact action from v3 to v4 in CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,7 +42,7 @@ jobs:
           pytest tests/integration --cov=src --cov-report=xml --disable-warnings
 
       - name: Upload coverage report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-report
           path: coverage.xml


### PR DESCRIPTION
CI workflow: Updated the `actions/upload-artifact` step from version `v3` to `v4` in `.github/workflows/ci.yaml`.